### PR TITLE
Docker pentaho

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,3 +45,22 @@ services:
         environment:
             - DB_USER=postgres
             - DB_PASS=admin123
+    pentaho-pdi:
+        build: dockerfiles/pentaho-pdi
+        ports:
+            - "8080"
+        links:
+            - db
+            - pentaho-biserver
+        volumes:
+            - /tmp/.X11-unix:/tmp/.X11-unix:rw
+            - /tmp/.docker.xauth:/tmp/.docker.xauth:rw
+            - ./transformacoes.sh:/opt/pentaho/data-integration/transformacoes.sh
+            - ./dados_teste:/opt/pentaho/data-integration/dados_teste
+            - ./dados_teste:/home/cristian/Documentos/LEDS/Projetos/Incaper/sipac-backend/dados_teste
+            - ./transformacoes:/opt/pentaho/data-integration/samples/transformations/Sipac
+            - ./jobs:/opt/pentaho/data-integration/samples/jobs/Sipac
+        environment:
+            - XAUTH=/tmp/.docker.xauth
+            - XAUTHORITY=/tmp/.docker.xauth
+            - DISPLAY

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
             - DB_USER=postgres
             - DB_PASS=admin123
     pentaho-pdi:
+        container_name: pdi
         build: dockerfiles/pentaho-pdi
         ports:
             - "8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,3 +36,12 @@ services:
         environment:
             - DATABASE_HOST=db
             - DATABASE_PORT=5432
+    pentaho-biserver:
+        image: leandrocp/pentaho-server
+        ports:
+            - "8080"
+        links:
+            - db:postgres
+        environment:
+            - DB_USER=postgres
+            - DB_PASS=admin123

--- a/dockerfiles/pentaho-pdi/Dockerfile
+++ b/dockerfiles/pentaho-pdi/Dockerfile
@@ -1,0 +1,2 @@
+FROM schoolscout/pentaho-kettle
+RUN apt-get -y install libswt-gtk-3-java firefox libgtk2.0-0

--- a/pan.sh
+++ b/pan.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+./pdi.sh ./pan.sh $@

--- a/pdi.sh
+++ b/pdi.sh
@@ -1,2 +1,2 @@
 #/bin/bash
-docker exec -it rdccosmosipacbackend_pentaho-pdi_1 $@
+docker exec -it pdi_1 $@

--- a/pdi.sh
+++ b/pdi.sh
@@ -1,0 +1,2 @@
+#/bin/bash
+docker exec -it rdccosmosipacbackend_pentaho-pdi_1 $@

--- a/spoon.sh
+++ b/spoon.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./pdi.sh ./spoon.sh

--- a/transformacoes.sh
+++ b/transformacoes.sh
@@ -1,0 +1,9 @@
+#!/bin/bash 
+
+./pan.sh -level=Minimal -file="/opt/pentaho/data-integration/samples/transformations/Sipac/extrai_estado.ktr"
+./pan.sh -level=Minimal -file="/opt/pentaho/data-integration/samples/transformations/Sipac/extrai_meso.ktr"
+./pan.sh -level=Minimal -file="/opt/pentaho/data-integration/samples/transformations/Sipac/extrai_micro.ktr"
+./pan.sh -level=Minimal -file="/opt/pentaho/data-integration/samples/transformations/Sipac/extrai_municipio.ktr"
+./pan.sh -level=Minimal -file="/opt/pentaho/data-integration/samples/transformations/Sipac/extrai_grupos.ktr"
+./pan.sh -level=Minimal -file="/opt/pentaho/data-integration/samples/transformations/Sipac/extrai_produto_subgrupo.ktr"
+./pan.sh -level=Minimal -file="/opt/pentaho/data-integration/samples/transformations/Sipac/extrai_producao.ktr"


### PR DESCRIPTION
# Objetivo

Adicionar ao docker-compose.yml os serviços
- [Pentaho BI Server ](81cf736)
- [Pentaho Data Integration](95bf1ff)
# Como usar
- Verifique se o [docker-compose](https://docs.docker.com/compose/install/) está instalado
- Mude o host do banco de dados em sipac/sipac/settings.py para db (conforme docker-compose.yml)
- Mude o host do banco de dados nos arquivos de transformação com o seguinte comando: `sed -i "s/localhost/db/g" transformacoes/*.ktr`
- Execute os comandos:

```
docker-compose up -d
docker ps
```
- A lista de containers conterá um serviço django, um postgres, um container temporário realizando as migrações, um serviço bi server e um serviço data integration
- Então execute as transformações conforme o script `transformacoes.sh`
