### PR TITLE
Pentaho fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,10 +41,7 @@ services:
         ports:
             - "8080"
         links:
-            - db:postgres
-        environment:
-            - DB_USER=postgres
-            - DB_PASS=admin123
+            - db
     pentaho-pdi:
         container_name: pdi
         build: dockerfiles/pentaho-pdi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,34 +8,7 @@ services:
             - POSTGRES_PASSWORD=admin123
             - POSTGRES_USER=postgres
             - POSTGRES_DB=Incaper
-    migrations:
-        build: dockerfiles/migrations
-        links:
-            - db
-            - web
-        depends_on:
-            - web
-        environment:
-            - DATABASE_NAME=Incaper
-            - DATABASE_USER=postgres
-            - DATABASE_PASSWORD=admin123
-            - DATABASE_PORT=5432
-            - DATABASE_ENCODING=utf8
-            - DATABASE_DRIVER=postgresql
-            - MIGRATIONS_PATH=/home/flyway/sql
-    web:
-        build: .
         volumes:
-            - .:/code
-        ports:
-            - "8000"
-        depends_on:
-            - db
-        links:
-            - db
-        environment:
-            - DATABASE_HOST=db
-            - DATABASE_PORT=5432
     pentaho-biserver:
         image: wmarinho/pentaho-biserver:6.1
         ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
             - POSTGRES_USER=postgres
             - POSTGRES_DB=Incaper
         volumes:
+            - ./dados_teste/sqls/Backup/Incaper.sql:/docker-entrypoint-initdb.d/populate_incaper_database.sql
     pentaho-biserver:
         image: wmarinho/pentaho-biserver:6.1
         ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
         container_name: pdi
         build: dockerfiles/pentaho-pdi
         ports:
-            - "8080"
+            - "8181"
         links:
             - db
             - pentaho-biserver

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,7 @@ services:
             - ./transformacoes.sh:/opt/pentaho/data-integration/transformacoes.sh
             - ./dados_teste:/opt/pentaho/data-integration/dados_teste
             - ./dados_teste:/home/cristian/Documentos/LEDS/Projetos/Incaper/sipac-backend/dados_teste
+            - ./dados_teste:/home/cristian/Documentos/LEDS/Projetos/Incaper/Testes Produção/files
             - ./transformacoes:/opt/pentaho/data-integration/samples/transformations/Sipac
             - ./jobs:/opt/pentaho/data-integration/samples/jobs/Sipac
         environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
             - DATABASE_HOST=db
             - DATABASE_PORT=5432
     pentaho-biserver:
-        image: leandrocp/pentaho-server
+        image: wmarinho/pentaho-biserver:6.1
         ports:
             - "8080"
         links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,4 +61,4 @@ services:
         environment:
             - XAUTH=/tmp/.docker.xauth
             - XAUTHORITY=/tmp/.docker.xauth
-            - DISPLAY
+            - DISPLAY=$DISPLAY

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,7 @@ services:
             - ./dados_teste:/home/cristian/Documentos/LEDS/Projetos/Incaper/Testes Produção/files
             - ./transformacoes:/opt/pentaho/data-integration/samples/transformations/Sipac
             - ./jobs:/opt/pentaho/data-integration/samples/jobs/Sipac
+            - $HOME/.kettle:/home/pentaho/.kettle
         environment:
             - XAUTH=/tmp/.docker.xauth
             - XAUTHORITY=/tmp/.docker.xauth

--- a/dockerfiles/pentaho-pdi/Dockerfile
+++ b/dockerfiles/pentaho-pdi/Dockerfile
@@ -1,2 +1,47 @@
-FROM schoolscout/pentaho-kettle
-RUN apt-get -y install libswt-gtk-3-java firefox libgtk2.0-0
+FROM java:7
+# Init ENV
+ENV PENTAHO_VERSION 6.1
+ENV PENTAHO_TAG 6.1.0.1-196
+
+ENV PENTAHO_HOME /opt/pentaho
+
+# Apply JAVA_HOME
+RUN . /etc/environment
+ENV PENTAHO_JAVA_HOME $JAVA_HOME
+ENV PENTAHO_JAVA_HOME /usr/lib/jvm/java-1.7.0-openjdk-amd64
+ENV JAVA_HOME /usr/lib/jvm/java-1.7.0-openjdk-amd64
+
+RUN apt-get update -y \
+    && apt-get -y install wget unzip libswt-gtk-3-java libwebkitgtk-1.0-0 libswt-gtk-3-java xz-utils \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# nao ta extraindo, com problema no formato do xf ou o xz-utils nao instalado
+RUN cd /tmp \
+    && wget http://http.debian.net/debian/pool/main/s/swt4-gtk/swt4-gtk_4.6.0-2.debian.tar.xz \
+    && tar xf swt4-gtk_4.6.0-2.debian.tar.xz -C /tmp \
+    && make -C debian \
+    && make -C debian install \
+    && rm -rf /tmp/*
+
+RUN groupadd -r pentaho && useradd -r -g pentaho pentaho \
+    && mkdir $PENTAHO_HOME && chown -R pentaho:pentaho $PENTAHO_HOME
+USER pentaho 
+
+# Download Pentaho BI Server
+RUN /usr/bin/wget --progress=dot:giga http://downloads.sourceforge.net/project/pentaho/Data%20Integration/${PENTAHO_VERSION}/pdi-ce-${PENTAHO_TAG}.zip -O /tmp/pdi-ce-${PENTAHO_TAG}.zip; \
+    /usr/bin/unzip -q /tmp/pdi-ce-${PENTAHO_TAG}.zip -d  $PENTAHO_HOME; \
+     rm /tmp/pdi-ce-${PENTAHO_TAG}.zip
+
+# /usr/lib/jni/libswt-gtk-3836.so
+# install libswt-gtk-4-java
+# libswt-gtk-4-java no in apt => compile
+ENV LIBPATH $LIBPATH:/usr/lib/jni
+
+COPY scripts/ /opt/pentaho/data-integration/
+COPY slave_dyn.xml /opt/pentaho/data-integration/
+
+WORKDIR /opt/pentaho/data-integration
+
+EXPOSE 8181
+
+CMD ["./run.sh"]

--- a/pdi.sh
+++ b/pdi.sh
@@ -1,2 +1,2 @@
 #/bin/bash
-docker exec -it pdi_1 $@
+docker exec -it pdi $@


### PR DESCRIPTION
Este PR:
- conserta a incompatibilidade entre o biserver e o pdi instalando a versão 6.1 em ambos   57fbaa0 e           8db7f9e, respectivamente
- substitui a etapa de migrações cd6a462  por inicialização com backup aaaea21
